### PR TITLE
Update seapony.yml

### DIFF
--- a/seapony.yml
+++ b/seapony.yml
@@ -1,17 +1,17 @@
-Title: "&2Earth"
-Tag: "&6[&2Earth&6]"
-FullTitle: "&2Earth Pony"
-SignText: "[Earth]"
-ActiveSign: "&4[&2Earth&4]"
+Title: "&2Seapony"
+Tag: "&6[&bSeapony&6]"
+FullTitle: "&bSeapony"
+SignText: "[Seapony]"
+ActiveSign: "&4[&bSeapony&4]"
 Description:
-  - "&2Earth Ponies&6 - The Masters of the Earth"
-  - "&6Earth Ponies have a advantages when mining or farming"
-  - "&6They have a knack for potions, and skilled with a bow or axe"
-  - "&6A herbivore, some foods are better for you, but avoid non-meat foods"
+  - "&bSeaponies&6 - "
+  - "&6"
+  - "&6"
+  - "&6Have mostly herbivore tendencies, but quite enjoy fish, raw or cooked."
 CommandsJoin:
-  - pex user {player} group add earth
+  - pex user {player} group add seapony
 CommandsLeave:
-  - pex user {player} group remove earth
+  - pex user {player} group remove seapony
 # this does not make items edible, but replace default values
 FoodModifiers:
   APPLE: # 4, 2.4
@@ -19,18 +19,18 @@ FoodModifiers:
     Saturation: 3
   BAKED_POTATO: # 5, 6
     Food: 6
-    Saturation: 6
+    Saturation: 4
   BEETROOT: # 1, 1.2
     Food: 3
     Saturation: 2
   BEETROOT_SOUP: # 6, 7.2
     Food: 8
-    Saturation: 8
+    Saturation: 6
     Effects:
     - "REGENERATION:2:5"
   BREAD: # 5, 6
     Food: 6
-    Saturation: 6
+    Saturation: 4
   CAKE: # 2, 0.4
     Food: 4
     Saturation: 3
@@ -48,8 +48,8 @@ FoodModifiers:
     Food: 3
     Saturation: 3
   DRIED_KELP: # 1, 0.6
-    Food: 3
-    Saturation: 2
+    Food: 5
+    Saturation: 4
   GOLDEN_APPLE: # 4, 9.6, REGENERATION:2:5, ABSORPTION:1:120
     Food: 5
     Saturation: 9.6
@@ -69,7 +69,7 @@ FoodModifiers:
     Saturation: 2
   MUSHROOM_STEW: # 6, 7.2
     Food: 8
-    Saturation: 8
+    Saturation: 6
   POISONOUS_POTATO: # 2, 1.2, 60%POISON:1:4
     Food: 3
     Saturation: 2
@@ -77,12 +77,12 @@ FoodModifiers:
     - "30%WEAKNESS:1:20"
     - "50%SPEED:2:10"
     - "40%JUMP:1:20"
-  POTATO: # 1, 0.6
+  POTATO: # 1, 0.6A herbivore, some foods are better for you, but avoid non-meat foods
     Food: 3
     Saturation: 2
   PUMPKIN_PIE: # 8, 4.8
     Food: 10
-    Saturation: 6
+    Saturation: 5
   COOKED_BEEF: # 8, 12.8
     Food: 3
     Saturation: 1.8
@@ -97,11 +97,8 @@ FoodModifiers:
     - "20%CONFUSION:1:10"
     - "20%WEAKNESS:1:60"
   COOKED_COD: # 5, 6
-    Food: 2
-    Saturation: 1.6
-    Effects:
-    - "20%CONFUSION:1:10"
-    - "20%WEAKNESS:1:60"
+    Food: 6
+    Saturation: 4
   COOKED_MUTTON: # 6, 9.6
     Food: 2
     Saturation: 1.6
@@ -121,11 +118,8 @@ FoodModifiers:
     - "20%CONFUSION:1:10"
     - "20%WEAKNESS:1:60"
   COOKED_SALMON: # 6, 9.6
-    Food: 2
-    Saturation: 1.8
-    Effects:
-    - "20%CONFUSION:1:10"
-    - "20%WEAKNESS:1:60"
+    Food: 6
+    Saturation: 4
   BEEF: # 3, 1.8, 30%HUNGER:1:30
     Food: 1
     Saturation: 0.8
@@ -143,13 +137,8 @@ FoodModifiers:
     - "70%POISON:1:6"
     - "50%HUNGER:1:50"
   COD: # 2, 0.4
-    Food: 1
-    Saturation: 0.2
-    Effects:
-    - "20%CONFUSION:1:10"
-    - "20%WEAKNESS:1:60"
-    - "70%POISON:1:6"
-    - "50%HUNGER:1:50"
+    Food: 6
+    Saturation: 4
   MUTTON: # 2, 1.2
     Food: 1
     Saturation: 0.8
@@ -159,7 +148,7 @@ FoodModifiers:
     - "70%POISON:1:6"
     - "50%HUNGER:1:50"
   PORKCHOP: # 3, 1.8
-    Food: 1
+    Food: 1A herbivore, some foods are better for you, but avoid non-meat foods
     Saturation: 0.8
     Effects:
     - "20%CONFUSION:1:10"
@@ -192,13 +181,8 @@ FoodModifiers:
     - "70%POISON:1:6"
     - "80%HUNGER:1:50"
   SALMON: # 2, 0.4
-    Food: 1
-    Saturation: 0.2
-    Effects:
-    - "20%CONFUSION:1:10"
-    - "20%WEAKNESS:1:60"
-    - "70%POISON:1:6"
-    - "80%HUNGER:1:50"
+    Food: 6
+    Saturation: 4
   SPIDER_EYE: # 2, 3.2, POISON:1:4
     Food: 5
     Saturation: 3
@@ -211,12 +195,8 @@ FoodModifiers:
     - "10%LEVITATION:1:5"
     - "20%POISON:1:4"
   TROPICAL_FISH: # 1, 0.2
-    Food: 1
-    Saturation: 0.5
-    Effects:
-    - "20%CONFUSION:1:10"
-    - "20%WEAKNESS:1:60"
-    - "80%HUNGER:1:50"
+    Food: 6
+    Saturation: 4
 
 TpaCost: 8
 TpaDelay: 5


### PR DESCRIPTION
Made seaponies able to eat fish, as well as a unique ability to digest them raw. Reduced some other food saturation values to compensate, though they may have to be reduced further for balance.

Changed the main titles and such from earth pony data, including the pex groups (which are guessed at and may be incorrect).